### PR TITLE
Various fixes to the DAOS tensorflow-io plugin.

### DIFF
--- a/dfs_filesystem.cc
+++ b/dfs_filesystem.cc
@@ -1,0 +1,736 @@
+#include "tensorflow_io/core/filesystems/dfs/dfs_utils.h"
+
+#include <stdio.h>
+#undef NDEBUG
+#include <cassert>
+
+namespace tensorflow {
+namespace io {
+namespace dfs {
+
+
+// SECTION 1. Implementation for `TF_RandomAccessFile`
+// ----------------------------------------------------------------------------
+namespace tf_random_access_file {
+typedef struct DFSRandomAccessFile {
+  std::string dfs_path;
+  dfs_t* daos_fs;
+  dfs_obj_t *daos_file;
+  std::vector<ReadBuffer> buffers;
+  daos_size_t file_size;
+  daos_handle_t mEventQueueHandle{};
+
+  DFSRandomAccessFile(std::string dfs_path, dfs_t* file_system, dfs_obj_t* obj)
+      : dfs_path(std::move(dfs_path)) {
+    daos_fs = file_system;
+    daos_file = obj;
+    dfs_get_size(daos_fs, obj, &file_size);
+    size_t num_of_buffers;
+    size_t buff_size;
+    int rc = daos_eq_create(&mEventQueueHandle);
+    assert(rc == 0);
+
+    if (char* env_num_of_buffers = std::getenv("TF_IO_DAOS_NUM_OF_BUFFERS")) {
+      num_of_buffers = atoi(env_num_of_buffers);
+    } else {
+      num_of_buffers = NUM_OF_BUFFERS;
+    }
+
+    if (char* env_buff_size = std::getenv("TF_IO_DAOS_BUFFER_SIZE")) {
+      buff_size = GetStorageSize(env_buff_size);
+    } else {
+      buff_size = BUFF_SIZE;
+    }
+    for (size_t i = 0; i < num_of_buffers; i++) {
+      buffers.push_back(ReadBuffer(i, mEventQueueHandle, buff_size));
+    }
+  }
+} DFSRandomAccessFile;
+
+void Cleanup(TF_RandomAccessFile* file) {
+  auto dfs_file = static_cast<DFSRandomAccessFile*>(file->plugin_file);
+  dfs_file->buffers.clear();
+
+  int rc = daos_eq_destroy(dfs_file->mEventQueueHandle, 0);
+  assert(rc == 0);
+  rc = dfs_release(dfs_file->daos_file);
+  assert(rc == 0);
+  dfs_file->daos_fs = nullptr;
+  delete dfs_file;
+}
+
+int64_t Read(const TF_RandomAccessFile* file, uint64_t offset, size_t n,
+             char* ret, TF_Status* status) {
+  auto dfs_file = static_cast<DFSRandomAccessFile*>(file->plugin_file);
+  if (offset >= dfs_file->file_size) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "");
+    return -1;
+  }
+
+  size_t ret_offset = 0;
+  size_t curr_offset = offset;
+  int64_t total_bytes = 0;
+  size_t ret_size = offset + n;
+  while (curr_offset < ret_size && curr_offset < dfs_file->file_size) {
+    int64_t read_bytes = 0;
+    for (auto& read_buf : dfs_file->buffers) {
+      if (read_buf.CacheHit(curr_offset)) {
+        read_bytes = read_buf.CopyFromCache(ret, ret_offset, curr_offset, n,
+                                            dfs_file->file_size, status);
+	break;
+      }
+    }
+
+    if (read_bytes < 0) {
+      return -1;
+    }
+
+    if (read_bytes > 0) {
+      curr_offset += read_bytes;
+      ret_offset += read_bytes;
+      total_bytes += read_bytes;
+      n -= read_bytes;
+      continue;
+    }
+
+    size_t async_offset = curr_offset;
+    for (size_t i = 0; i < dfs_file->buffers.size(); i++) {
+      if (async_offset > dfs_file->file_size) break;
+      dfs_file->buffers[i].ReadAsync(dfs_file->daos_fs,
+                                     dfs_file->daos_file, async_offset);
+      async_offset += BUFF_SIZE;
+    }
+  }
+
+  return total_bytes;
+}
+
+}  // namespace tf_random_access_file
+
+// SECTION 2. Implementation for `TF_WritableFile`
+// ----------------------------------------------------------------------------
+namespace tf_writable_file {
+typedef struct DFSWritableFile {
+  std::string dfs_path;
+  dfs_t* daos_fs;
+  dfs_obj_t *daos_file;
+  daos_size_t file_size;
+  bool size_known;
+
+  DFSWritableFile(std::string dfs_path, dfs_t* file_system, dfs_obj_t* obj)
+      : dfs_path(std::move(dfs_path)) {
+    daos_fs = file_system;
+    daos_file = obj;
+    size_known=false;
+  }
+
+  int get_file_size(daos_size_t &size) {
+    if (!size_known) {
+      int rc = dfs_get_size(daos_fs, daos_file, &file_size);
+      if (rc != 0) {
+        return rc;
+      }
+      size_known = true;
+    }
+    size = file_size;
+    return 0;
+  }
+
+  void set_file_size(daos_size_t size) {
+    file_size = size;
+    size_known = true;
+  }
+
+  void unset_file_size(void) {
+    size_known = false;
+  }
+} DFSWritableFile;
+
+void Cleanup(TF_WritableFile* file) {
+  auto dfs_file = static_cast<DFSWritableFile*>(file->plugin_file);
+  dfs_release(dfs_file->daos_file);
+  dfs_file->daos_fs = nullptr;
+  delete dfs_file;
+}
+
+void Append(const TF_WritableFile* file, const char* buffer, size_t n,
+            TF_Status* status) {
+  d_sg_list_t wsgl;
+  d_iov_t iov;
+  int rc;
+  auto dfs_file = static_cast<DFSWritableFile*>(file->plugin_file);
+
+  d_iov_set(&iov, (void*)buffer, n);
+  wsgl.sg_nr = 1;
+  wsgl.sg_iovs = &iov;
+
+  daos_size_t cur_file_size;
+  rc = dfs_file->get_file_size(cur_file_size);
+  if (rc != 0) {
+    TF_SetStatus(status, TF_INTERNAL, "Cannot determine file size");
+    return;
+  }
+
+  rc = dfs_write(dfs_file->daos_fs, dfs_file->daos_file, &wsgl,
+                 cur_file_size, NULL);
+  if (rc) {
+    TF_SetStatus(status, TF_RESOURCE_EXHAUSTED, "");
+    dfs_file->unset_file_size();
+    return;
+  }
+
+  dfs_file->set_file_size(cur_file_size + n);
+  TF_SetStatus(status, TF_OK, "");
+}
+
+int64_t Tell(const TF_WritableFile* file, TF_Status* status) {
+  auto dfs_file = static_cast<DFSWritableFile*>(file->plugin_file);
+
+  daos_size_t cur_file_size;
+  int rc = dfs_file->get_file_size(cur_file_size);
+  if (rc != 0) {
+    TF_SetStatus(status, TF_INTERNAL, "Cannot determine file size");
+    return -1;
+  }
+
+  TF_SetStatus(status, TF_OK, "");
+  return cur_file_size;
+}
+
+void Close(const TF_WritableFile* file, TF_Status* status) {
+  auto dfs_file = static_cast<DFSWritableFile*>(file->plugin_file);
+  dfs_release(dfs_file->daos_file);
+  dfs_file->daos_fs = nullptr;
+  dfs_file->daos_file = nullptr;
+  TF_SetStatus(status, TF_OK, "");
+}
+
+}  // namespace tf_writable_file
+
+// SECTION 3. Implementation for `TF_ReadOnlyMemoryRegion`
+// ----------------------------------------------------------------------------
+namespace tf_read_only_memory_region {
+void Cleanup(TF_ReadOnlyMemoryRegion* region) {}
+
+const void* Data(const TF_ReadOnlyMemoryRegion* region) { return nullptr; }
+
+uint64_t Length(const TF_ReadOnlyMemoryRegion* region) { return 0; }
+
+}  // namespace tf_read_only_memory_region
+
+// SECTION 4. Implementation for `TF_Filesystem`, the actual filesystem
+// ----------------------------------------------------------------------------
+namespace tf_dfs_filesystem {
+
+void Init(TF_Filesystem* filesystem, TF_Status* status) {
+  filesystem->plugin_filesystem = new DFS();
+  TF_SetStatus(status, TF_OK, "");
+}
+
+void Cleanup(TF_Filesystem* filesystem) {
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem);
+  daos->dfsCleanup();
+  delete daos;
+}
+
+void NewFile(const TF_Filesystem* filesystem, const char* path, File_Mode mode,
+             int flags, dfs_obj_t** obj, TF_Status* status) {
+  int rc;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  std::string pool, cont, file_path;
+  rc = daos->Setup(path, pool, cont, file_path, status);
+  if (rc) return;
+  daos->dfsNewFile(file_path, mode, flags, obj, status);
+}
+
+void NewWritableFile(const TF_Filesystem* filesystem, const char* path,
+                     TF_WritableFile* file, TF_Status* status) {
+  dfs_obj_t* obj = NULL;
+  NewFile(filesystem, path, WRITE, S_IWUSR | S_IFREG, &obj, status);
+  if (TF_GetCode(status) != TF_OK) return;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  file->plugin_file =
+      new tf_writable_file::DFSWritableFile(path, daos->daos_fs, obj);
+  TF_SetStatus(status, TF_OK, "");
+}
+
+void NewRandomAccessFile(const TF_Filesystem* filesystem, const char* path,
+                         TF_RandomAccessFile* file, TF_Status* status) {
+  dfs_obj_t* obj = NULL;
+  NewFile(filesystem, path, READ, S_IRUSR | S_IFREG, &obj, status);
+  if (TF_GetCode(status) != TF_OK) return;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  auto random_access_file =
+      new tf_random_access_file::DFSRandomAccessFile(path, daos->daos_fs, obj);
+  random_access_file->buffers[0].ReadAsync(
+      daos->daos_fs, random_access_file->daos_file, 0);
+  file->plugin_file = random_access_file;
+  TF_SetStatus(status, TF_OK, "");
+}
+
+void NewAppendableFile(const TF_Filesystem* filesystem, const char* path,
+                       TF_WritableFile* file, TF_Status* status) {
+  dfs_obj_t* obj = NULL;
+  NewFile(filesystem, path, APPEND, S_IWUSR | S_IFREG, &obj, status);
+  if (TF_GetCode(status) != TF_OK) return;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  file->plugin_file =
+      new tf_writable_file::DFSWritableFile(path, daos->daos_fs, obj);
+  TF_SetStatus(status, TF_OK, "");
+}
+
+void PathExists(const TF_Filesystem* filesystem, const char* path,
+                TF_Status* status) {
+  int rc;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  std::string pool, cont, file;
+  rc = daos->Setup(path, pool, cont, file, status);
+  if (rc) return;
+  dfs_obj_t* obj;
+  rc = daos->dfsPathExists(file, &obj);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+  } else {
+    TF_SetStatus(status, TF_OK, "");
+  }
+}
+
+void CreateDir(const TF_Filesystem* filesystem, const char* path,
+               TF_Status* status) {
+  int rc;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  std::string pool, cont, dir_path;
+  rc = daos->Setup(path, pool, cont, dir_path, status);
+  if (rc) return;
+
+  daos->dfsCreateDir(dir_path, status);
+}
+
+static void RecursivelyCreateDir(const TF_Filesystem* filesystem,
+                                 const char* path, TF_Status* status) {
+  int rc;
+  std::string pool, cont, dir_path;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  rc = daos->Setup(path, pool, cont, dir_path, status);
+  if (rc) return;
+
+  size_t next_dir = 0;
+  std::string dir_string;
+  std::string path_string(dir_path);
+  do {
+    next_dir = path_string.find("/", next_dir);
+    dir_string = path_string.substr(0, next_dir);
+    if (next_dir != std::string::npos) next_dir++;
+    daos->dfsCreateDir(dir_string, status);
+    if ((TF_GetCode(status) != TF_OK) &&
+        (TF_GetCode(status) != TF_ALREADY_EXISTS))
+      return;
+    TF_SetStatus(status, TF_OK, "");
+
+  } while (next_dir != std::string::npos);
+}
+
+void DeleteFileSystemEntry(const TF_Filesystem* filesystem, const char* path,
+                           bool recursive, bool is_dir, TF_Status* status) {
+  int rc;
+  std::string pool, cont, dir_path;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+
+  rc = daos->Setup(path, pool, cont, dir_path, status);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+
+  daos->dfsDeleteObject(dir_path, is_dir, recursive, status);
+}
+
+void DeleteSingleDir(const TF_Filesystem* filesystem, const char* path,
+                     TF_Status* status) {
+  bool recursive = false;
+  bool is_dir = true;
+  DeleteFileSystemEntry(filesystem, path, recursive, is_dir, status);
+}
+
+void RecursivelyDeleteDir(const TF_Filesystem* filesystem, const char* path,
+                          uint64_t* undeleted_files, uint64_t* undeleted_dirs,
+                          TF_Status* status) {
+  bool recursive = true;
+  bool is_dir = true;
+  DeleteFileSystemEntry(filesystem, path, recursive, is_dir, status);
+  if (TF_GetCode(status) == TF_NOT_FOUND ||
+      TF_GetCode(status) == TF_FAILED_PRECONDITION) {
+    *undeleted_dirs = 1;
+    *undeleted_files = 0;
+  } else {
+    *undeleted_dirs = 0;
+    *undeleted_files = 0;
+  }
+}
+
+bool IsDir(const TF_Filesystem* filesystem, const char* path,
+           TF_Status* status) {
+  int rc;
+  bool is_dir = false;
+  std::string pool, cont, file;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return is_dir;
+  }
+  rc = daos->Setup(path, pool, cont, file, status);
+  if (rc) return is_dir;
+
+  if (daos->isRoot(file)) {
+    is_dir = true;
+    return is_dir;
+  }
+
+  dfs_obj_t* obj;
+  rc = daos->dfsPathExists(file, &obj, 0);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+  } else {
+    is_dir = S_ISDIR(obj->mode);
+  }
+
+  dfs_release(obj);
+
+  if (is_dir) {
+    TF_SetStatus(status, TF_OK, "");
+  } else {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+  }
+
+  return is_dir;
+}
+
+int64_t GetFileSize(const TF_Filesystem* filesystem, const char* path,
+                    TF_Status* status) {
+  int rc;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return -1;
+  }
+  std::string pool, cont, file;
+  rc = daos->Setup(path, pool, cont, file, status);
+  if (rc) return -1;
+
+  dfs_obj_t* obj;
+  rc = daos->dfsPathExists(file, &obj, 0);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    return -1;
+  } else {
+    if (S_ISDIR(obj->mode)) {
+      TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+      return -1;
+    }
+    TF_SetStatus(status, TF_OK, "");
+    daos_size_t size;
+    dfs_get_size(daos->daos_fs, obj, &size);
+    dfs_release(obj);
+    return size;
+  }
+}
+
+void DeleteFile(const TF_Filesystem* filesystem, const char* path,
+                TF_Status* status) {
+  bool recursive = false;
+  bool is_dir = false;
+  DeleteFileSystemEntry(filesystem, path, recursive, is_dir, status);
+}
+
+void RenameFile(const TF_Filesystem* filesystem, const char* src,
+                const char* dst, TF_Status* status) {
+  int rc;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  int allow_cont_creation = 1;
+  std::string pool_src, cont_src, file_src;
+  rc = ParseDFSPath(src, pool_src, cont_src, file_src);
+  if (rc) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    return;
+  }
+
+  std::string pool_dst, cont_dst, file_dst;
+  rc = ParseDFSPath(dst, pool_dst, cont_dst, file_dst);
+  if (rc) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    return;
+  }
+
+  if (pool_src != pool_dst || cont_src != cont_dst) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "Non-Matching Pool/Container");
+    return;
+  }
+
+  daos->Connect(pool_src, cont_src, allow_cont_creation, status);
+  if (TF_GetCode(status) != TF_OK) {
+    return;
+  }
+
+  rc = daos->Mount();
+  if (rc != 0) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Mounting DFS");
+    return;
+  }
+
+  file_src = "/" + file_src;
+  file_dst = "/" + file_dst;
+
+  dfs_obj_t* temp_obj;
+  rc = daos->dfsPathExists(file_src, &temp_obj, 0);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    return;
+  } else {
+    if (S_ISDIR(temp_obj->mode)) {
+      TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+      dfs_release(temp_obj);
+      return;
+    }
+  }
+
+  dfs_release(temp_obj);
+  rc = daos->dfsPathExists(file_dst, &temp_obj, 0);
+  if (!rc && S_ISDIR(temp_obj->mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    dfs_release(temp_obj);
+    return;
+  }
+
+  dfs_release(temp_obj);
+
+  dfs_obj_t* parent_src = NULL;
+  size_t src_start = file_src.rfind("/") + 1;
+  std::string src_name = file_src.substr(src_start);
+  rc = daos->dfsFindParent(file_src, &parent_src);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    dfs_release(parent_src);
+    return;
+  }
+
+  dfs_obj_t* parent_dst = NULL;
+  size_t dst_start = file_dst.rfind("/") + 1;
+  std::string dst_name = file_dst.substr(dst_start);
+  rc = daos->dfsFindParent(file_dst, &parent_dst);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    dfs_release(parent_dst);
+    return;
+  }
+
+  if (!S_ISDIR(parent_dst->mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    dfs_release(parent_dst);
+    return;
+  }
+
+  char* name = (char*)malloc(src_name.size());
+  strcpy(name, src_name.c_str());
+  char* new_name = (char*)malloc(dst_name.size());
+  strcpy(new_name, dst_name.c_str());
+
+  rc = dfs_move(daos->daos_fs, parent_src, name, parent_dst, new_name, NULL);
+  free(name);
+  free(new_name);
+  dfs_release(parent_src);
+  dfs_release(parent_dst);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "");
+    return;
+  }
+
+  TF_SetStatus(status, TF_OK, "");
+}
+
+void Stat(const TF_Filesystem* filesystem, const char* path,
+          TF_FileStatistics* stats, TF_Status* status) {
+  int rc;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return;
+  }
+  std::string pool, cont, dir_path;
+  rc = daos->Setup(path, pool, cont, dir_path, status);
+  if (rc) return;
+
+  dfs_obj_t* obj;
+  rc = daos->dfsPathExists(dir_path, &obj, 0);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    return;
+  }
+
+  if (S_ISDIR(obj->mode)) {
+    stats->is_directory = true;
+    stats->length = 0;
+  } else {
+    stats->is_directory = false;
+    daos_size_t size;
+    dfs_get_size(daos->daos_fs, obj, &size);
+    stats->length = size;
+  }
+
+  struct stat stbuf;
+
+  dfs_ostat(daos->daos_fs, obj, &stbuf);
+
+  stats->mtime_nsec = static_cast<int64_t>(stbuf.st_mtime) * 1e9;
+
+  dfs_release(obj);
+
+  TF_SetStatus(status, TF_OK, "");
+}
+
+int GetChildren(const TF_Filesystem* filesystem, const char* path,
+                char*** entries, TF_Status* status) {
+  int rc;
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    TF_SetStatus(status, TF_INTERNAL, "Error initializing DAOS API");
+    return -1;
+  }
+  std::string pool, cont, dir_path;
+  rc = daos->Setup(path, pool, cont, dir_path, status);
+  if (rc) return -1;
+
+  dfs_obj_t* obj;
+  rc = daos->dfsPathExists(dir_path, &obj, 0);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    dfs_release(obj);
+    return -1;
+  }
+
+  if (!S_ISDIR(obj->mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    dfs_release(obj);
+    return -1;
+  }
+
+  std::vector<std::string> children;
+  rc = daos->dfsReadDir(obj, children);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "");
+    dfs_release(obj);
+    return -1;
+  }
+
+  dfs_release(obj);
+
+  uint32_t nr = children.size();
+
+  CopyEntries(entries, children);
+
+  TF_SetStatus(status, TF_OK, "");
+  return nr;
+}
+
+static char* TranslateName(const TF_Filesystem* filesystem, const char* uri) {
+  return strdup(uri);
+}
+
+void FlushCaches(const TF_Filesystem* filesystem) {
+  auto daos = static_cast<DFS*>(filesystem->plugin_filesystem)->Load();
+  if (!daos) {
+    return;
+  }
+  daos->ClearConnections();
+}
+
+}  // namespace tf_dfs_filesystem
+
+void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops, const char* uri) {
+  TF_SetFilesystemVersionMetadata(ops);
+  ops->scheme = strdup(uri);
+
+  ops->random_access_file_ops = static_cast<TF_RandomAccessFileOps*>(
+      plugin_memory_allocate(TF_RANDOM_ACCESS_FILE_OPS_SIZE));
+  ops->random_access_file_ops->cleanup = tf_random_access_file::Cleanup;
+  ops->random_access_file_ops->read = tf_random_access_file::Read;
+
+  ops->writable_file_ops = static_cast<TF_WritableFileOps*>(
+      plugin_memory_allocate(TF_WRITABLE_FILE_OPS_SIZE));
+  ops->writable_file_ops->cleanup = tf_writable_file::Cleanup;
+  ops->writable_file_ops->append = tf_writable_file::Append;
+  ops->writable_file_ops->tell = tf_writable_file::Tell;
+  ops->writable_file_ops->close = tf_writable_file::Close;
+
+  ops->read_only_memory_region_ops = static_cast<TF_ReadOnlyMemoryRegionOps*>(
+      plugin_memory_allocate(TF_READ_ONLY_MEMORY_REGION_OPS_SIZE));
+  ops->read_only_memory_region_ops->cleanup =
+      tf_read_only_memory_region::Cleanup;
+  ops->read_only_memory_region_ops->data = tf_read_only_memory_region::Data;
+  ops->read_only_memory_region_ops->length = tf_read_only_memory_region::Length;
+
+  ops->filesystem_ops = static_cast<TF_FilesystemOps*>(
+      plugin_memory_allocate(TF_FILESYSTEM_OPS_SIZE));
+  ops->filesystem_ops->init = tf_dfs_filesystem::Init;
+  ops->filesystem_ops->cleanup = tf_dfs_filesystem::Cleanup;
+  ops->filesystem_ops->new_random_access_file =
+      tf_dfs_filesystem::NewRandomAccessFile;
+  ops->filesystem_ops->new_writable_file = tf_dfs_filesystem::NewWritableFile;
+  ops->filesystem_ops->new_appendable_file =
+      tf_dfs_filesystem::NewAppendableFile;
+  ops->filesystem_ops->path_exists = tf_dfs_filesystem::PathExists;
+  ops->filesystem_ops->create_dir = tf_dfs_filesystem::CreateDir;
+  ops->filesystem_ops->delete_dir = tf_dfs_filesystem::DeleteSingleDir;
+  ops->filesystem_ops->recursively_create_dir =
+      tf_dfs_filesystem::RecursivelyCreateDir;
+  ops->filesystem_ops->is_directory = tf_dfs_filesystem::IsDir;
+  ops->filesystem_ops->delete_recursively =
+      tf_dfs_filesystem::RecursivelyDeleteDir;
+  ops->filesystem_ops->get_file_size = tf_dfs_filesystem::GetFileSize;
+  ops->filesystem_ops->delete_file = tf_dfs_filesystem::DeleteFile;
+  ops->filesystem_ops->rename_file = tf_dfs_filesystem::RenameFile;
+  ops->filesystem_ops->stat = tf_dfs_filesystem::Stat;
+  ops->filesystem_ops->get_children = tf_dfs_filesystem::GetChildren;
+  ops->filesystem_ops->translate_name = tf_dfs_filesystem::TranslateName;
+  ops->filesystem_ops->flush_caches = tf_dfs_filesystem::FlushCaches;
+}
+
+}  // namespace dfs
+}  // namespace io
+}  // namespace tensorflow

--- a/dfs_utils.cc
+++ b/dfs_utils.cc
@@ -1,0 +1,594 @@
+#include "tensorflow_io/core/filesystems/dfs/dfs_utils.h"
+
+#include <stdio.h>
+#undef NDEBUG
+#include <cassert>
+
+std::string GetStorageString(uint64_t size) {
+  if (size < KILO) {
+    return std::to_string(size);
+  } else if (size < MEGA) {
+    return std::to_string(size / KILO) + "K";
+  } else if (size < GEGA) {
+    return std::to_string(size / MEGA) + "M";
+  } else if (size < TERA) {
+    return std::to_string(size / GEGA) + "G";
+  } else {
+    return std::to_string(size / TERA) + "T";
+  }
+}
+
+size_t GetStorageSize(std::string size) {
+  char size_char = size.back();
+  size_t curr_scale = 1;
+  switch (size_char) {
+    case 'K':
+      size.pop_back();
+      curr_scale *= 1024;
+      return (size_t)atoi(size.c_str()) * curr_scale;
+    case 'M':
+      size.pop_back();
+      curr_scale *= 1024 * 1024;
+      return (size_t)atoi(size.c_str()) * curr_scale;
+    case 'G':
+      size.pop_back();
+      curr_scale *= 1024 * 1024 * 1024;
+      return (size_t)atoi(size.c_str()) * curr_scale;
+    case 'T':
+      size.pop_back();
+      curr_scale *= 1024 * 1024 * 1024;
+      return (size_t)atoi(size.c_str()) * curr_scale * 1024;
+    default:
+      return atoi(size.c_str());
+  }
+}
+
+mode_t GetFlags(File_Mode mode) {
+  switch (mode) {
+    case READ:
+      return O_RDONLY;
+    case WRITE:
+      return O_WRONLY | O_CREAT;
+    case APPEND:
+      return O_WRONLY | O_APPEND | O_CREAT;
+    default:
+      return -1;
+  }
+}
+
+int ParseDFSPath(const std::string& path, std::string& pool_string,
+                 std::string& cont_string, std::string& filename) {
+  size_t pool_start = path.find("://") + 3;
+  struct duns_attr_t* attr =
+      (struct duns_attr_t*)malloc(sizeof(struct duns_attr_t));
+  attr->da_rel_path = NULL;
+  attr->da_flags = 1;
+  attr->da_no_prefix = true;
+  std::string direct_path = "/" + path.substr(pool_start);
+  int rc = duns_resolve_path(direct_path.c_str(), attr);
+  if (rc == 2) {
+    attr->da_rel_path = NULL;
+    attr->da_flags = 0;
+    attr->da_no_prefix = false;
+    direct_path = "daos://" + path.substr(pool_start);
+    rc = duns_resolve_path(direct_path.c_str(), attr);
+    if (rc) return rc;
+  }
+  pool_string = attr->da_pool;
+  cont_string = attr->da_cont;
+  filename = attr->da_rel_path == NULL ? "" : attr->da_rel_path;
+  duns_destroy_attr(attr);
+  return 0;
+}
+
+int ParseUUID(const std::string& str, uuid_t uuid) {
+  return uuid_parse(str.c_str(), uuid);
+}
+
+void CopyEntries(char*** entries, std::vector<std::string>& results) {
+  *entries = static_cast<char**>(
+      tensorflow::io::plugin_memory_allocate(results.size() * sizeof(char*)));
+
+  for (uint32_t i = 0; i < results.size(); i++) {
+    (*entries)[i] = static_cast<char*>(tensorflow::io::plugin_memory_allocate(
+        results[i].size() * sizeof(char)));
+    if (results[i][0] == '/') results[i].erase(0, 1);
+    strcpy((*entries)[i], results[i].c_str());
+  }
+}
+
+bool Match(const std::string& filename, const std::string& pattern) {
+  return fnmatch(pattern.c_str(), filename.c_str(), FNM_PATHNAME) == 0;
+}
+
+DFS::DFS() {
+  daos_fs = (dfs_t*)malloc(sizeof(dfs_t));
+  daos_fs->mounted = false;
+  is_initialized = false;
+}
+
+DFS::~DFS() { free(daos_fs); }
+
+DFS* DFS::Load() {
+  if (!is_initialized) {
+    int rc = dfsInit();
+    if (rc) {
+      return nullptr;
+    }
+    is_initialized = true;
+  }
+  return this;
+}
+
+int DFS::dfsInit() { return daos_init(); }
+
+void DFS::dfsCleanup() {
+  Teardown();
+  if (is_initialized) {
+    daos_fini();
+    is_initialized = false;
+  }
+}
+
+int DFS::Setup(const std::string& path, std::string& pool_string,
+               std::string& cont_string, std::string& file_path,
+               TF_Status* status) {
+  int allow_cont_creation = 1;
+  int rc;
+  rc = ParseDFSPath(path, pool_string, cont_string, file_path);
+  if (rc) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    return rc;
+  }
+  Connect(pool_string, cont_string, allow_cont_creation, status);
+  if (TF_GetCode(status) != TF_OK) {
+    return -1;
+  }
+  return Mount();
+}
+
+void DFS::Teardown() {
+  Unmount();
+  ClearConnections();
+}
+
+void DFS::Connect(std::string& pool_string, std::string& cont_string,
+                  int allow_cont_creation, TF_Status* status) {
+  int rc;
+
+  rc = ConnectPool(pool_string, status);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Connecting to Pool");
+    return;
+  }
+
+  rc = ConnectContainer(cont_string, allow_cont_creation, status);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Connecting to Container");
+    return;
+  }
+
+  connected = true;
+
+  TF_SetStatus(status, TF_OK, "");
+}
+
+void DFS::Disconnect(TF_Status* status) {
+  int rc;
+  rc = DisconnectContainer(pool.first, container.first);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Disconnecting from Container");
+    return;
+  }
+
+  rc = DisconnectPool(pool.first);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Disconnecting from Pool");
+    return;
+  }
+
+  connected = false;
+
+  TF_SetStatus(status, TF_OK, "");
+}
+
+int DFS::Mount() {
+  int rc = 0;
+  if (daos_fs->mounted) {
+    if (daos_fs->poh.cookie == pool.second.cookie &&
+        daos_fs->coh.cookie == container.second.cookie) {
+      return rc;
+    }
+    rc = Unmount();
+    if (rc) return rc;
+  }
+  return dfs_mount(pool.second, container.second, O_RDWR, &daos_fs);
+}
+
+int DFS::Unmount() {
+  int rc;
+  if (!daos_fs->mounted) return 0;
+  rc = dfs_umount(daos_fs);
+  daos_fs = (dfs_t*)malloc(sizeof(dfs_t));
+  daos_fs->mounted = false;
+  return rc;
+}
+
+int DFS::Query() {
+  int rc;
+  daos_pool_info_t pool_info;
+  daos_cont_info_t cont_info;
+  if (connected) {
+    memset(&pool_info, 'D', sizeof(daos_pool_info_t));
+    pool_info.pi_bits = DPI_ALL;
+    rc = daos_pool_query(pool.second, NULL, &pool_info, NULL, NULL);
+    if (rc) return rc;
+    rc = daos_cont_query(container.second, &cont_info, NULL, NULL);
+    if (rc) return rc;
+    std::cout << "Pool " << pool.first << " ntarget=" << pool_info.pi_ntargets
+              << std::endl;
+    std::cout << "Pool space info:" << std::endl;
+    std::cout << "- Target(VOS) count:" << pool_info.pi_space.ps_ntargets
+              << std::endl;
+    std::cout << "- SCM:" << std::endl;
+    std::cout << "  Total size: "
+              << GetStorageString(pool_info.pi_space.ps_space.s_total[0]);
+    std::cout << "  Free: "
+              << GetStorageString(pool_info.pi_space.ps_space.s_free[0])
+              << std::endl;
+    std::cout << "- NVMe:" << std::endl;
+    std::cout << "  Total size: "
+              << GetStorageString(pool_info.pi_space.ps_space.s_total[1]);
+    std::cout << "  Free: "
+              << GetStorageString(pool_info.pi_space.ps_space.s_free[1])
+              << std::endl;
+    std::cout << std::endl
+              << "Connected Container: " << container.first << std::endl;
+
+    return 0;
+  }
+
+  return -1;
+}
+
+int DFS::ClearConnections() {
+  int rc;
+  rc = Unmount();
+  if (rc) return rc;
+  for (auto pool_it = pools.cbegin(); pool_it != pools.cend();) {
+    for (auto cont_it = (*(*pool_it).second->containers).cbegin();
+         cont_it != (*(*pool_it).second->containers).cend();) {
+      rc = DisconnectContainer((*pool_it).first, (*cont_it++).first);
+      if (rc) return rc;
+    }
+    rc = DisconnectPool((*pool_it++).first);
+    if (rc) return rc;
+  }
+
+  return rc;
+}
+
+int DFS::dfsDeleteObject(std::string& dir_path, bool is_dir, bool recursive,
+                         TF_Status* status) {
+  dfs_obj_t* temp_obj;
+  int rc = dfsPathExists(dir_path, &temp_obj, 0);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    return -1;
+  }
+  if (!is_dir && S_ISDIR(temp_obj->mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    return -1;
+  }
+  dfs_release(temp_obj);
+
+  size_t dir_start = dir_path.rfind("/") + 1;
+  std::string dir = dir_path.substr(dir_start);
+  dfs_obj_t* parent;
+  rc = dfsFindParent(dir_path, &parent);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    return -1;
+  }
+
+  rc = dfs_remove(daos_fs, parent, dir.c_str(), recursive, NULL);
+
+  dfs_release(parent);
+
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Deleting Existing Object");
+  } else {
+    TF_SetStatus(status, TF_OK, "");
+  }
+
+  return rc;
+}
+
+void DFS::dfsNewFile(std::string& file_path, File_Mode file_mode, int flags,
+                     dfs_obj_t** obj, TF_Status* status) {
+  int rc;
+  dfs_obj_t* temp_obj;
+  mode_t open_flags;
+  rc = dfsPathExists(file_path, &temp_obj, 0);
+  if (rc && flags == O_RDONLY) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    return;
+  }
+
+  if (temp_obj != NULL && S_ISDIR(temp_obj->mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    dfs_release(temp_obj);
+    return;
+  }
+
+  if (temp_obj != NULL) {
+    dfs_release(temp_obj);
+  }
+
+  if (!rc && file_mode == WRITE) {
+    rc = dfsDeleteObject(file_path, false, false, status);
+    if (rc) return;
+  }
+
+  open_flags = GetFlags(file_mode);
+
+  dfs_obj_t* parent;
+  rc = dfsFindParent(file_path, &parent);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    dfs_release(parent);
+    return;
+  }
+  if (parent != NULL && !S_ISDIR(parent->mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "");
+    return;
+  }
+
+  size_t file_start = file_path.rfind("/") + 1;
+  std::string file_name = file_path.substr(file_start);
+
+  rc = dfs_open(daos_fs, parent, file_name.c_str(), flags, open_flags, 0, 0,
+                NULL, obj);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Creating Writable File");
+    return;
+  }
+}
+
+int DFS::dfsPathExists(std::string& file, dfs_obj_t** obj, int release_obj) {
+  (*obj) = NULL;
+  int rc = 0;
+  if (isRoot(file)) {
+    return rc;
+  }
+  if (file.front() != '/') file = "/" + file;
+  rc = dfs_lookup(daos_fs, file.c_str(), O_RDONLY, obj, NULL, NULL);
+  if (release_obj) dfs_release(*obj);
+  return rc;
+}
+
+int DFS::dfsFindParent(std::string& file, dfs_obj_t** parent) {
+  (*parent) = NULL;
+  size_t file_start = file.rfind("/") + 1;
+  std::string parent_path = file.substr(0, file_start);
+  if (parent_path != "/") {
+    return dfs_lookup(daos_fs, parent_path.c_str(), O_RDONLY, parent, NULL,
+                      NULL);
+  } else {
+    (*parent) = NULL;
+    return 0;
+  }
+}
+
+int DFS::dfsCreateDir(std::string& dir_path, TF_Status* status) {
+  dfs_obj_t* temp_obj;
+  int rc;
+  rc = dfsPathExists(dir_path, &temp_obj);
+  if (!rc) {
+    TF_SetStatus(status, TF_ALREADY_EXISTS, "");
+    return rc;
+  }
+
+  size_t dir_start = dir_path.rfind("/") + 1;
+  std::string dir = dir_path.substr(dir_start);
+  dfs_obj_t* parent;
+  rc = dfsFindParent(dir_path, &parent);
+  if (rc) {
+    TF_SetStatus(status, TF_NOT_FOUND, "");
+    return rc;
+  }
+
+  rc = dfs_mkdir(daos_fs, parent, dir.c_str(), S_IWUSR | S_IRUSR, 0);
+  if (rc) {
+    TF_SetStatus(status, TF_INTERNAL, "Error Creating Directory");
+  } else {
+    TF_SetStatus(status, TF_OK, "");
+  }
+
+  dfs_release(parent);
+
+  return rc;
+}
+
+bool DFS::isRoot(std::string& file_path) { return file_path.empty(); }
+
+int DFS::dfsReadDir(dfs_obj_t* obj, std::vector<std::string>& children) {
+  int rc = 0;
+  daos_anchor_t anchor = {0};
+  uint32_t nr = STACK;
+  struct dirent* dirs = (struct dirent*)malloc(nr * sizeof(struct dirent));
+  while (!daos_anchor_is_eof(&anchor)) {
+    rc = dfs_readdir(daos_fs, obj, &anchor, &nr, dirs);
+    if (rc) {
+      return rc;
+    }
+
+    for (uint32_t i = 0; i < nr; i++) {
+      children.emplace_back(dirs[i].d_name);
+    }
+  }
+
+  free(dirs);
+  return rc;
+}
+
+int DFS::ConnectPool(std::string pool_string, TF_Status* status) {
+  int rc = 0;
+
+  if (pools.find(pool_string) != pools.end()) {
+    pool.first = pool_string;
+    pool.second = pools[pool_string]->poh;
+    return rc;
+  }
+
+  pool_info_t* po_inf = (pool_info_t*)malloc(sizeof(po_inf));
+  rc = daos_pool_connect(pool_string.c_str(), NULL, DAOS_PC_RW, &(po_inf->poh),
+                         NULL, NULL);
+  if (rc == 0) {
+    pool.first = pool_string;
+    pool.second = po_inf->poh;
+    po_inf->containers = new std::map<std::string, daos_handle_t>();
+    pools[pool_string] = po_inf;
+  }
+  return rc;
+}
+
+int DFS::ConnectContainer(std::string cont_string, int allow_creation,
+                          TF_Status* status) {
+  int rc = 0;
+
+  pool_info_t* po_inf = pools[pool.first];
+  if (po_inf->containers->find(cont_string) != po_inf->containers->end()) {
+    container.first = cont_string;
+    container.second = (*po_inf->containers)[cont_string];
+    return rc;
+  }
+
+  daos_handle_t coh;
+
+  rc = daos_cont_open(pool.second, cont_string.c_str(), DAOS_COO_RW, &coh, NULL,
+                      NULL);
+  if (rc == -DER_NONEXIST) {
+    if (allow_creation) {
+      rc = dfs_cont_create_with_label(pool.second, cont_string.c_str(), NULL,
+                                      NULL, &coh, NULL);
+    }
+  }
+  if (rc == 0) {
+    container.first = cont_string;
+    container.second = coh;
+    (*po_inf->containers)[cont_string] = coh;
+  }
+  return rc;
+}
+
+int DFS::DisconnectPool(std::string pool_string) {
+  int rc = 0;
+  daos_handle_t poh = pools[pool_string]->poh;
+  rc = daos_pool_disconnect(poh, NULL);
+  if (rc == 0) {
+    delete pools[pool_string]->containers;
+    free(pools[pool_string]);
+    pools.erase(pool_string);
+  }
+  return rc;
+}
+
+int DFS::DisconnectContainer(std::string pool_string, std::string cont_string) {
+  int rc = 0;
+  daos_handle_t coh = (*pools[pool_string]->containers)[cont_string];
+  rc = daos_cont_close(coh, 0);
+  if (rc == 0) {
+    pools[pool_string]->containers->erase(cont_string);
+  }
+  return rc;
+}
+
+ReadBuffer::ReadBuffer(size_t id, daos_handle_t eqh, size_t size)
+    : id(id), buffer_size(size), eqh(eqh) {
+  buffer = new char[size];
+  buffer_offset = ULONG_MAX;
+  event = new daos_event_t;
+  int rc = daos_event_init(event, eqh, nullptr);
+  assert(rc == 0);
+}
+
+ReadBuffer::~ReadBuffer() {
+  if (event != nullptr) {
+    WaitEvent();
+    int rc = daos_event_fini(event);
+    assert(rc == 0);
+    delete event;
+  }
+  if (buffer != nullptr) {
+    delete[] buffer;
+  }
+}
+
+ReadBuffer::ReadBuffer(ReadBuffer&& read_buffer) {
+  eqh = read_buffer.eqh;
+  buffer_size = read_buffer.buffer_size;
+  buffer = std::move(read_buffer.buffer);
+  event = std::move(read_buffer.event);
+  buffer_offset = ULONG_MAX;
+  id = read_buffer.id;
+  read_buffer.buffer = nullptr;
+  read_buffer.event = nullptr;
+}
+
+bool ReadBuffer::CacheHit(const size_t pos) {
+  return pos >= buffer_offset && (pos < buffer_offset + buffer_size);
+}
+
+void ReadBuffer::WaitEvent() {
+  bool event_status;
+  int rc = daos_event_test(event, DAOS_EQ_WAIT, &event_status);
+  assert(rc == 0 && event_status == true);
+}
+
+int ReadBuffer::ReadAsync(dfs_t* daos_fs, dfs_obj_t* file, const size_t off) {
+  WaitEvent();
+  d_iov_set(&iov, (void*)buffer, buffer_size);
+  rsgl.sg_nr = 1;
+  rsgl.sg_iovs = &iov;
+  buffer_offset = off;
+  int rc = daos_event_fini(event);
+  assert(rc == 0);
+  rc = daos_event_init(event, eqh, nullptr);
+  assert(rc == 0);
+  event->ev_error = dfs_read(daos_fs, file, &rsgl, buffer_offset, &read_size, event);
+  return 0;
+}
+
+int ReadBuffer::CopyData(char* ret, const size_t ret_offset, const size_t off,
+                         const size_t n) {
+  WaitEvent();
+  if (event->ev_error != DER_SUCCESS) {
+    return event->ev_error;
+  }
+  memcpy(ret + ret_offset, buffer + (off - buffer_offset), n);
+  return 0;
+}
+
+int64_t ReadBuffer::CopyFromCache(char* ret, const size_t ret_offset,
+                              const size_t off, const size_t n,
+                              const daos_size_t file_size, TF_Status* status) {
+  size_t read_size;
+  read_size = off + n > file_size ? file_size - off : n;
+  read_size = off + read_size > buffer_offset + buffer_size
+                  ? buffer_offset + buffer_size - off
+                  : read_size;
+  int rc = CopyData(ret, ret_offset, off, read_size);
+  if (rc) {
+    TF_SetStatusFromIOError(status, rc, "I/O error on dfs_read() call");
+    return -1;
+  }
+
+  if (off + n > file_size) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "");
+  } else {
+    TF_SetStatus(status, TF_OK, "");
+  }
+
+  return static_cast<int64_t>(read_size);
+}

--- a/dfs_utils.h
+++ b/dfs_utils.h
@@ -1,0 +1,226 @@
+#ifndef TENSORFLOW_IO_CORE_FILESYSTEMS_DFS_DFS_FILESYSTEM_H_
+#define TENSORFLOW_IO_CORE_FILESYSTEMS_DFS_DFS_FILESYSTEM_H_
+
+#define KILO 1e3
+#define MEGA 1e6
+#define GEGA 1e9
+#define TERA 1e12
+#define POOL_START 6
+#define CONT_START 43
+#define PATH_START 80
+#define STACK 24
+#define NUM_OF_BUFFERS 256
+#define BUFF_SIZE 4 * 1024 * 1024
+
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_uns.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+#include <sys/stat.h>
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "tensorflow/c/logging.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow_io/core/filesystems/filesystem_plugins.h"
+
+/** object struct that is instantiated for a DFS open object */
+struct dfs_obj {
+  /** DAOS object ID */
+  daos_obj_id_t oid;
+  /** DAOS object open handle */
+  daos_handle_t oh;
+  /** mode_t containing permissions & type */
+  mode_t mode;
+  /** open access flags */
+  int flags;
+  /** DAOS object ID of the parent of the object */
+  daos_obj_id_t parent_oid;
+  /** entry name of the object in the parent */
+  char name[DFS_MAX_NAME + 1];
+  union {
+    /** Symlink value if object is a symbolic link */
+    char* value;
+    struct {
+      /** Default object class for all entries in dir */
+      daos_oclass_id_t oclass;
+      /** Default chunk size for all entries in dir */
+      daos_size_t chunk_size;
+    } d;
+  };
+};
+
+/** dfs struct that is instantiated for a mounted DFS namespace */
+struct dfs {
+  /** flag to indicate whether the dfs is mounted */
+  bool mounted;
+  /** flag to indicate whether dfs is mounted with balanced mode (DTX) */
+  bool use_dtx;
+  /** lock for threadsafety */
+  pthread_mutex_t lock;
+  /** uid - inherited from container. */
+  uid_t uid;
+  /** gid - inherited from container. */
+  gid_t gid;
+  /** Access mode (RDONLY, RDWR) */
+  int amode;
+  /** Open pool handle of the DFS */
+  daos_handle_t poh;
+  /** Open container handle of the DFS */
+  daos_handle_t coh;
+  /** Object ID reserved for this DFS (see oid_gen below) */
+  daos_obj_id_t oid;
+  /** superblock object OID */
+  daos_obj_id_t super_oid;
+  /** Open object handle of SB */
+  daos_handle_t super_oh;
+  /** Root object info */
+  dfs_obj_t root;
+  /** DFS container attributes (Default chunk size, oclass, etc.) */
+  dfs_attr_t attr;
+  /** Optional prefix to account for when resolving an absolute path */
+  char* prefix;
+  daos_size_t prefix_len;
+};
+
+struct dfs_entry {
+  /** mode (permissions + entry type) */
+  mode_t mode;
+  /** Object ID if not a symbolic link */
+  daos_obj_id_t oid;
+  /* Time of last access */
+  time_t atime;
+  /* Time of last modification */
+  time_t mtime;
+  /* Time of last status change */
+  time_t ctime;
+  /** chunk size of file */
+  daos_size_t chunk_size;
+  /** Sym Link value */
+  char* value;
+};
+
+typedef struct pool_info {
+  daos_handle_t poh;
+  std::map<std::string, daos_handle_t>* containers;
+} pool_info_t;
+
+typedef std::pair<std::string, daos_handle_t> id_handle_t;
+
+enum File_Mode { READ, WRITE, APPEND };
+
+std::string GetStorageString(uint64_t size);
+
+size_t GetStorageSize(std::string size);
+
+// parse DFS path in the format of dfs://<pool_uuid>/<cont_uuid>/<filename>
+int ParseDFSPath(const std::string& path, std::string& pool_string,
+                 std::string& cont_string, std::string& filename);
+
+int ParseUUID(const std::string& str, uuid_t uuid);
+
+class DFS {
+ public:
+  bool connected;
+  dfs_t* daos_fs;
+  id_handle_t pool;
+  id_handle_t container;
+  std::map<std::string, pool_info_t*> pools;
+
+  DFS();
+
+  DFS* Load();
+
+  int dfsInit();
+
+  void dfsCleanup();
+
+  int Setup(const std::string& path, std::string& pool_string,
+            std::string& cont_string, std::string& file_path,
+            TF_Status* status);
+
+  void Teardown();
+
+  void Connect(std::string& pool_string, std::string& cont_string,
+               int allow_cont_creation, TF_Status* status);
+
+  void Disconnect(TF_Status* status);
+
+  int Mount();
+
+  int Unmount();
+
+  int Query();
+
+  int ClearConnections();
+
+  void dfsNewFile(std::string& file_path, File_Mode mode, int flags,
+                  dfs_obj_t** obj, TF_Status* status);
+
+  int dfsPathExists(std::string& file, dfs_obj_t** obj, int release_obj = 1);
+
+  int dfsFindParent(std::string& file, dfs_obj_t** parent);
+
+  int dfsCreateDir(std::string& dir_path, TF_Status* status);
+
+  int dfsDeleteObject(std::string& dir_path, bool is_dir, bool recursive,
+                      TF_Status* status);
+
+  bool isRoot(std::string& file_path);
+
+  int dfsReadDir(dfs_obj_t* obj, std::vector<std::string>& children);
+
+  ~DFS();
+
+ private:
+  bool is_initialized;
+  int ConnectPool(std::string pool_string, TF_Status* status);
+
+  int ConnectContainer(std::string cont_string, int allow_creation,
+                       TF_Status* status);
+
+  int DisconnectPool(std::string pool_string);
+
+  int DisconnectContainer(std::string pool_string, std::string cont_string);
+};
+
+void CopyEntries(char*** entries, std::vector<std::string>& results);
+
+class ReadBuffer {
+ public:
+  ReadBuffer(size_t id, daos_handle_t eqh, size_t size);
+
+  ReadBuffer(ReadBuffer&&);
+
+  ~ReadBuffer();
+
+  bool CacheHit(const size_t pos);
+
+  void WaitEvent();
+
+  int ReadAsync(dfs_t* dfs, dfs_obj_t* file, const size_t off);
+
+  int CopyData(char* ret, const size_t ret_offset, const size_t offset,
+               const size_t n);
+
+  int64_t CopyFromCache(char* ret, const size_t ret_offset, const size_t off,
+                    const size_t n, const daos_size_t file_size,
+                    TF_Status* status);
+
+ private:
+  size_t id;
+  char* buffer;
+  size_t buffer_offset;
+  size_t buffer_size;
+  daos_handle_t eqh;
+  daos_event_t* event;
+  d_sg_list_t rsgl;
+  d_iov_t iov;
+  daos_size_t read_size;
+};
+
+#endif  // TENSORFLOW_IO_CORE_FILESYSTEMS_DFS_DFS_FILESYSTEM_H_


### PR DESCRIPTION
General:
    Asserts were added and enabled after each DAOS event-related call in order
    to track down internal race conditions in the DAOS client code, see
    DAOS-10601.

    The DAOS_FILE structure documented behavior for the 'offset' field, but
    most of that behavior didn't need to be implemented.  Field 'offset' was
    removed while fixing the Append() and Tell() functions, leaving only a
    single field 'file' in DAOS_FILE, so the DAOS_FILE struct was removed as
    well.

    Typos in error messages were corrected.

File dfs_utils.cc:

In DFS::Setup():
   Code after the Connect() call replaced the detailed error status set in
   Connect() with a generic TF_NOT_FOUND error with no accompanying message.
   This cost me several days of debugging to realize that a problem was not
   some object not being found, but rather was a connection failure to an
   unhealthy container.  The TF_NOT_FOUND has been removed, allowing the more
   detailed error messages in Connect() to be reported.

In ReadBuffer::ReadBuffer()
    By setting buffer_offset to ULONG_MAX, an uninitialized buffer will never
    be matched by CacheHit(), removing the need for a separate 'initialized'
    variable.  The valid variable is no longer needed as well, more on that
    below.

In ReadBuffer::~ReadBuffer()
    daos_event_fini(() cannot be called on an event that is still in flight,
    it fails without doing anything, daos_event_test() must wait for any prior
    event to complete, otherwise the event delete that follows
    daos_event_fini() could then cause corruption of the event queue.  Call the
    reworked WaitEvent() (see below) first to ensure that daos_event_fini()
    will clean up the event before it is deleted.

In ReadBuffer::FinalizeEvent()
    The same problem exists here as in ~ReadBuffer(), daos_event_fini() can't
    be called on an event that is still in flight.  However, FinalizeEvent()
    isn't actually needed, a call to dfs_file->buffers.clear() in Cleanup()
    accomplishes the same thing using the ~ReadBuffer code, so FinalizeEvent
    was removed.

ReadBuffer::WaitEvent()
    There is a need for a WaitEvent() function in several places to wait for
    any outstanding event to complete, but this routine manipulates 'valid',
    so it can't be used anywhere else.  Removed the 'valid' code so that this
    routine can become a void and be called in multiple places.

ReadBuffer::AbortEvent()
    daos_event_abort() doesn't actually contain any logic to ask the server to
    abort an in-flight dfs_read() request.  In addition it is buggy, internal
    DAOS asserts were hit due to daos_event_abort() calls during I/O testing.
    The code was changed to instead use WaitEvent() to simply wait for a prior
    read to complete before issuing a new one, and AbortEvent() was removed.

ReadBuffer::ReadAsync()
    Both daos_event_fini() and daos_event_init() must be called on a
    daos_event_t structure before the event can be reused for another
    dfs_read() call.  These have been added.  The AbortEvent() call was
    replaced with a call to WaitEvent().  The code was changed to save the
    errno from a failed dfs_read() call in the event's ev_error field so
    that the error will be detected, and so a user cannot accidentally read
    trash data after a failed dfs_read() call.

ReadBuffer::ReadSync()
    This function is no longer used, see below.

ReadBuffer::CopyData()
    The WaitEvent() call ensures that the thread blocks until any in-flight
    read request is done.  The event->ev_error field is used to detect I/O
    failure either at the time the dfs_read() is issued or in the reply, so
    the valid flag is no longer needed.

ReadBuffer::CopyFromCache()
    The TF_RandomAccessFile read() function allows for int64_t-sized reads, so
    change the return value here to int64_t.  If an I/O error occurred, then
    return -1 so that the caller function Read() can easily tell when there
    has been an I/O error.  Provide a detailed error message so that the user
    can tell what caused the error.

File dfs_filesystem.cc:

In DFSRandomAccessFile constructor:
    Added an assert() on the event queue creation.

In Cleanup():
    Replaced FinalizeEvent() code with a dfs_file->buffers.clear() call.
    Add asserts on dfs function calls.

In df_dfs_filesystem::Read():
    The loop "for (auto& read_buf : dfs_file->buffers)" was missing a break
    statement, so CacheHit was called 256 times for each curr_offset value.
    A break was added.

    Support was added for detecting a read error and returning -1.

    Since Read() is now a while loop, there is no reason to specially use
    ReadSync() for the first buffer.  Code changed to use ReadAsync() for
    all readahead, CopyFromCache() will block until the first buffer's I/O
    is complete.  ReadSync is now unused, and is removed.

    I could not determine a reason for the WaitEvent loop:
        if (curr_offset >= dfs_file->file_size)
    because I/O requests will never be be started beyond EOF.  The loop
    was removed.

In DFSWritableFile:
   The Append() function had to make a dfs_get_size() call for each append
   to a file, adding a second round trip to the server for each append.  This
   is very expensive.  Member functions were added to cache the file size
   and update it locally as Append() operations are done..  Since the
   tensorflow API only allows one writer, local caching is allowable.  Should
   there be an I/O error, the actual size of the file becomes unknown, the
   new member functions take that into account and call dfs_get_size() in
   those situations to reestablish the correct size of the file.

In Append():
   The dfs_file->daos_file.offset field was not updated after an Append()
   operation completed successfully, so a subsequent Tell() call would return
   the size of the file before the last Append(), not after, the reported size
   was incorrect.  The code was changed to update the cached file size after
   successful Append() operations.

In RenameFile():
    Similar to the Setup() case, the detailed error statuses in Connect() were
    being hidden by a genereric TF_NOT_FOUND error.  The generic error was
    removed.