### PR TITLE
Add support for dynamically loaded DAOS libraries

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -293,11 +293,11 @@ http_archive(
 http_archive(
     name = "daos",
     build_file = "//third_party:daos.BUILD",
-    sha256 = "6fb24cf72a1d07d9f9efcd738bba210e927b25526a5f01763ad39d0aabee5f76",
-    strip_prefix = "daos-1.3.106-tb",
+    sha256 = "9789a5a0065cfa4249105f1676b9eba89f68b54bc03083140549b7a8a8f615d3",
+    strip_prefix = "daos-2.0.2",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/daos-stack/daos/archive/refs/tags/v1.3.106-tb.tar.gz",
-        "https://github.com/daos-stack/daos/archive/refs/tags/v1.3.106-tb.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/daos-stack/daos/archive/refs/tags/v2.0.2.tar.gz",
+        "https://github.com/daos-stack/daos/archive/refs/tags/v2.0.2.tar.gz",
     ],
 )
 

--- a/tensorflow_io/core/filesystems/dfs/BUILD
+++ b/tensorflow_io/core/filesystems/dfs/BUILD
@@ -15,15 +15,11 @@ cc_library(
         "dfs_utils.h",
     ],
     copts = tf_io_copts(),
-    linkopts = [
-        "-ldaos",
-        "-luuid",
-        "-ldfs",
-        "-lduns",
-    ],
     linkstatic = True,
     deps = [
         "//tensorflow_io/core/filesystems:filesystem_plugins_header",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
         "@daos",
     ],
     alwayslink = 1,

--- a/tensorflow_io/core/filesystems/dfs/dfs_utils.h
+++ b/tensorflow_io/core/filesystems/dfs/dfs_utils.h
@@ -19,7 +19,11 @@
 #include <fnmatch.h>
 #include <sys/stat.h>
 
+#include "absl/strings/str_cat.h"
+#include "absl/synchronization/mutex.h"
+#include <functional>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -119,24 +123,105 @@ size_t GetStorageSize(std::string size);
 
 int ParseUUID(const std::string& str, uuid_t uuid);
 
+
+class libDFS {
+  public:
+    explicit libDFS(TF_Status* status) { LoadAndBindDaosLibs(status); }
+
+    ~libDFS();
+
+    std::function<int(daos_handle_t, daos_event_t*)>daos_cont_close;
+
+    std::function<int(daos_handle_t, const char*, unsigned int, daos_handle_t*,
+                      daos_cont_info_t*, daos_event_t*)>daos_cont_open2;
+
+    std::function<int(daos_handle_t, daos_cont_info_t*, daos_prop_t*,
+                      daos_event_t*)>daos_cont_query;
+
+    std::function<int(daos_event_t*, daos_handle_t,
+                      daos_event_t*)>daos_event_init;
+
+    std::function<int(daos_event_t*)>daos_event_fini;
+
+    std::function<int(struct daos_event*, int64_t, bool*)>daos_event_test;
+
+    std::function<int(daos_handle_t*)>daos_eq_create;
+
+    std::function<int(daos_handle_t, int)>daos_eq_destroy;
+
+    std::function<int(void)>daos_fini;
+
+    std::function<int(void)>daos_init;
+
+    std::function<int(const char*, const char*, unsigned int, daos_handle_t*,
+                      daos_pool_info_t*, daos_event_t*)>daos_pool_connect2;
+
+    std::function<int(daos_handle_t, daos_event_t*)>daos_pool_disconnect;
+
+    std::function<int(daos_handle_t, d_rank_list_t*, daos_pool_info_t*,
+                      daos_prop_t*, daos_event_t*)>daos_pool_query;
+
+    std::function<int(daos_handle_t, const char*, dfs_attr_t*, uuid_t*,
+                      daos_handle_t*, dfs_t **)> dfs_cont_create_with_label;
+
+    std::function<int(dfs_t*, dfs_obj_t*, daos_size_t*)>dfs_get_size;
+
+    std::function<int(dfs_t*, dfs_obj_t*, const char*, mode_t,
+                      daos_oclass_id_t)>dfs_mkdir;
+
+    std::function<int(daos_handle_t, daos_handle_t, int, dfs_t**)>dfs_mount;
+
+    std::function<int(dfs_t*, dfs_obj_t*, const char*, dfs_obj_t*, const char*,
+                      daos_obj_id_t*)>dfs_move;
+
+    std::function<int(dfs_t*, dfs_obj_t*, const char*, mode_t, int,
+                      daos_oclass_id_t, daos_size_t, const char*,
+                      dfs_obj_t**)>dfs_open;
+
+    std::function<int(dfs_t*, dfs_obj_t*, struct stat*)>dfs_ostat;
+
+    std::function<int(dfs_t*, dfs_obj_t*, d_sg_list_t*, daos_off_t,
+                      daos_size_t*, daos_event_t*)>dfs_read;
+
+    std::function<int(dfs_t*, dfs_obj_t*, daos_anchor_t*, uint32_t*,
+                      struct dirent*)>dfs_readdir;
+
+    std::function<int(dfs_obj_t*)>dfs_release;
+
+    std::function<int(dfs_t*, dfs_obj_t*, const char*, bool,
+                      daos_obj_id_t*)>dfs_remove;
+
+    std::function<int(dfs_t*)>dfs_umount;
+
+    std::function<int(dfs_t*, dfs_obj_t*, d_sg_list_t*, daos_off_t,
+                      daos_event_t*)>dfs_write;
+
+    std::function<void(struct duns_attr_t*)>duns_destroy_attr;
+
+    std::function<int(const char*, struct duns_attr_t*)>duns_resolve_path;
+
+  private:
+    void LoadAndBindDaosLibs(TF_Status* status);
+
+    void* libdaos_handle_;
+    void* libdfs_handle_;
+    void* libduns_handle_;
+};
+
 class DFS {
  public:
   bool connected;
   dfs_t* daos_fs;
   id_handle_t pool;
   id_handle_t container;
+
   daos_handle_t mEventQueueHandle;
+  std::unique_ptr<libDFS> libdfs;
   std::unordered_map<std::string, pool_info_t*> pools;
   std::unordered_map<std::string, dfs_obj_t*> path_map;
   static std::unordered_map<std::string, daos_size_t> size_map;
 
-  DFS();
-
-  DFS* Load();
-
-  int dfsInit();
-
-  void dfsCleanup();
+  explicit DFS(TF_Status* status);
 
   int ParseDFSPath(const std::string& path, std::string& pool_string,
                    std::string& cont_string, std::string& filename);
@@ -144,8 +229,6 @@ class DFS {
   int Setup(const std::string& path, std::string& pool_string,
             std::string& cont_string, std::string& file_path,
             TF_Status* status);
-
-  void Teardown();
 
   void Connect(std::string& pool_string, std::string& cont_string,
                int allow_cont_creation, TF_Status* status);
@@ -185,7 +268,6 @@ class DFS {
   ~DFS();
 
  private:
-  bool is_initialized;
   int ConnectPool(std::string pool_string, TF_Status* status);
 
   int ConnectContainer(std::string cont_string, int allow_creation,
@@ -200,7 +282,7 @@ void CopyEntries(char*** entries, std::vector<std::string>& results);
 
 class ReadBuffer {
  public:
-  ReadBuffer(size_t id, daos_handle_t eqh, size_t size);
+  ReadBuffer(size_t id, DFS *daos, daos_handle_t eqh, size_t size);
 
   ReadBuffer(ReadBuffer&&);
 
@@ -222,6 +304,7 @@ class ReadBuffer {
 
  private:
   size_t id;
+  DFS *daos;
   char* buffer;
   size_t buffer_offset;
   size_t buffer_size;

--- a/third_party/daos.BUILD
+++ b/third_party/daos.BUILD
@@ -27,6 +27,6 @@ genrule(
     cmd = ("sed " +
            "-e 's/@TMPL_MAJOR@/2/g' " +
            "-e 's/@TMPL_MINOR@/0/g' " +
-           "-e 's/@TMPL_FIX@/0/g' " +
+           "-e 's/@TMPL_FIX@/2/g' " +
            "$< >$@"),
 )


### PR DESCRIPTION
Currently if DAOS libraries are not installed on a node, the
libtensorflow_io_plugins.so will fail to load due to unsatisfied
externals, and all modular filesystems are then unusable, not
just DFS.  This PR changes the DFS plugin to dynamically load
the DAOS libraries so that the DFS filesystem is available if
DAOS is installed, but the other modular filesystems are still
available if DAOS is not installed.

The checks for the DAOS libraries and the daos_init() call are
now done at filesystem registration time, not as part of each
function call in the filesystem API.  If the libraries are not
installed then the DFS filesystem will not be not registered,
and no calls into DFS functions will ever occur.  In this case
tensorflow will just report
    "File system scheme 'dfs' not implemented"
when a "dfs://" path is used.

A number of separate functions existed each of which was only
called once as part of DFS destruction, these were combined into
the DFS destructor for simplicity.  Similar recombinations were
done to simplify DFS construction.